### PR TITLE
Unit tests for league, season and grades

### DIFF
--- a/server/controllers/gradeController.js
+++ b/server/controllers/gradeController.js
@@ -14,6 +14,7 @@ async function getGrade(req, res, next) {
 }
 
 // TODO: move this to a separate endpoint and decouple it from grades
+// Won't be writing a test for this atm until its refactored
 async function createTeam(req, res, next) {
     let { teamName } = req.body
     try {
@@ -37,10 +38,10 @@ async function createTeam(req, res, next) {
 
 async function getAllGradeTeams(req, res, next) {
     try {
-        await req.grade.execPopulate('teams')
+        const grade = await req.grade.execPopulate('teams')
         return res.status(200).json({
             success: true,
-            data: req.grade.teams,
+            data: grade.teams,
         })
     } catch (err) {
         console.log(err)

--- a/server/controllers/seasonController.js
+++ b/server/controllers/seasonController.js
@@ -1,4 +1,3 @@
-const Season = require('../models/season')
 const Grade = require('../models/grade')
 
 async function getSeason(req, res, next) {
@@ -27,13 +26,13 @@ async function createGrade(req, res, next) {
             difficulty: gradeDifficulty,
             season: req.season._id,
         })
-        await newGrade.save()
+        const grade = await newGrade.save()
         req.season.grades.push(newGrade)
         await req.season.save()
 
         return res.status(201).json({
             success: true,
-            data: newGrade,
+            data: grade,
         })
     } catch (err) {
         console.log(err)
@@ -43,10 +42,10 @@ async function createGrade(req, res, next) {
 
 async function getAllSeasonGrades(req, res, next) {
     try {
-        await req.season.execPopulate('grades')
+        const season = await req.season.execPopulate('grades')
         return res.status(200).json({
             success: true,
-            data: req.season.grades,
+            data: season.grades,
         })
     } catch (err) {
         console.log(err)

--- a/server/models/grade.js
+++ b/server/models/grade.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose')
 const gradeSchema = new mongoose.Schema({
     name: {
         type: String,
+        required: true,
     },
     difficulty: {
         type: String,

--- a/server/models/league.js
+++ b/server/models/league.js
@@ -3,9 +3,11 @@ const mongoose = require('mongoose')
 const leagueSchema = new mongoose.Schema({
     name: {
         type: String,
+        required: true,
     },
     organisation: {
         type: String,
+        required: true,
     },
     creator: {
         type: mongoose.Schema.Types.ObjectId,

--- a/server/tests/unit/gradeController.test.js
+++ b/server/tests/unit/gradeController.test.js
@@ -1,0 +1,94 @@
+const gradeController = require('../../controllers/gradeController')
+const Grade = require('../../models/grade')
+const Team = require('../../models/team')
+const { mockRequest, mockResponse, mockNext } = require('./test-utils')
+
+describe('Unit Testing: getAllGradeTeams in gradeController', () => {
+    test('Getting grade teams with 1 team should return populated team', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        const gradeDetails = {
+            _id: '612788ed698aac7c50c3d3b6',
+            name: 'jdubz',
+            gender: 'male',
+            difficulty: 'A',
+            season: '60741060d14008bd0efff9d5',
+            teams: ['611ba6a199599722e4d01c38'],
+        }
+        req.grade = new Grade(gradeDetails)
+
+        const expectedTeams = [
+            {
+                totalPoints: 0,
+                totalWins: 0,
+                totalLosses: 0,
+                totalDraws: 0,
+                gameResults: [],
+                _id: '611ba6a199599722e4d01c38',
+                name: 'jdubz',
+                grade: '612788ed698aac7c50c3d3b6',
+                __v: 0,
+            },
+        ]
+
+        // We expect execPopulate to populate the teams array with the full document
+        const populatedObj = {
+            ...gradeDetails,
+            teams: expectedTeams,
+        }
+
+        Grade.prototype.execPopulate = jest.fn().mockResolvedValue(populatedObj)
+
+        await gradeController.getAllGradeTeams(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: expectedTeams,
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+
+    test('Getting grade teams with no teams should return empty teams array', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        const gradeDetails = {
+            _id: '612788ed698aac7c50c3d3b6',
+            name: 'jdubz',
+            gender: 'male',
+            difficulty: 'A',
+            season: '60741060d14008bd0efff9d5',
+            teams: [],
+        }
+        req.grade = new Grade(gradeDetails)
+
+        Grade.prototype.execPopulate = jest.fn().mockResolvedValue(gradeDetails)
+
+        await gradeController.getAllGradeTeams(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: [],
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+})

--- a/server/tests/unit/leagueController.test.js
+++ b/server/tests/unit/leagueController.test.js
@@ -1,0 +1,562 @@
+const leagueController = require('../../controllers/leagueController')
+const League = require('../../models/league')
+const Season = require('../../models/season')
+const User = require('../../models/user')
+const { mockRequest, mockResponse, mockNext } = require('./test-utils')
+
+describe('Unit Testing: getAllLeagues in leagueController', () => {
+    test('Getting existing leagues (2) should return 2 leagues', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+        const allLeagues = [
+            {
+                _id: '611a8a661fb4c81d84a5512c',
+                admins: ['611a8a311fb4c81d84a55126'],
+                seasons: ['611b9bea1f374212cc10bb59'],
+                name: 'Joshua Basketball Association',
+                organisation: 'JoshuaDubar',
+                creator: '611a8a311fb4c81d84a55126',
+                __v: 8,
+            },
+            {
+                _id: '611bbfe2aaa94829988d0b18',
+                admin: ['611a8a311fb4c81d84a55126'],
+                seasons: [],
+                name: 'Joshua Basketball Association',
+                organisation: 'JoshuaDubar',
+                creator: '611a8a311fb4c81d84a55126',
+                __v: 0,
+            },
+        ]
+
+        League.find = jest.fn().mockResolvedValue(allLeagues)
+        League.find.mockImplementationOnce(() => ({
+            lean: jest.fn().mockReturnValue(allLeagues),
+        }))
+
+        await leagueController.getAllLeagues(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: allLeagues,
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+
+    test('Getting no existing leagues should return no leagues', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        League.find = jest.fn().mockResolvedValue([])
+        League.find.mockImplementationOnce(() => ({
+            lean: jest.fn().mockReturnValue([]),
+        }))
+
+        await leagueController.getAllLeagues(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: [],
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+})
+
+describe('Unit Testing: createLeague in leagueController', () => {
+    test('Creating league with valid leagueName and organisationName should create a league', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        req.user = new User({
+            _id: '611bbfe2aaa94829988d0b18',
+            leagues: [],
+        })
+
+        const leagueDetails = {
+            _id: '611bbfe2aaa94829988d0b18',
+            admin: ['611a8a311fb4c81d84a55126'],
+            seasons: [],
+            name: 'Joshua Basketball Association',
+            organisation: 'JoshuaDubar',
+            creator: '611a8a311fb4c81d84a55126',
+            __v: 0,
+        }
+
+        req.body = {
+            leagueName: 'Joshua Basketball Association',
+            organisationName: 'JoshuaDubar',
+        }
+
+        User.prototype.save = jest.fn().mockImplementationOnce()
+        League.prototype.save = jest.fn().mockResolvedValue(leagueDetails)
+        await leagueController.createLeague(req, res, next)
+
+        const actualRes = {
+            status: 201,
+            json: {
+                success: true,
+                data: leagueDetails,
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+})
+
+describe('Unit Testing: getAllLeagueSeasons in leagueController', () => {
+    test('Getting league seasons with 1 season should return populated season', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        const leagueDetails = {
+            _id: '611a8a661fb4c81d84a5512c',
+            admins: ['611a8a311fb4c81d84a55126'],
+            seasons: ['611b9bea1f374212cc10bb59'],
+            name: 'Joshua Basketball Association',
+            organisation: 'JoshuaDubar',
+            creator: '611a8a311fb4c81d84a55126',
+            __v: 8,
+        }
+        req.league = new League(leagueDetails)
+
+        const expectedSeasons = [
+            {
+                _id: '611b9bea1f374212cc10bb59',
+                status: 'upcoming',
+                grades: [],
+                name: 'Summer 2020/2021',
+                league: '611a8a661fb4c81d84a5512c',
+                dateStart: '2021-08-12T12:23:34.944Z',
+                dateFinish: '2021-08-14T12:23:34.944Z',
+                __v: 0,
+            },
+        ]
+
+        // We expect execPopulate to populate the seasons array with the full document
+        const populatedObj = {
+            ...leagueDetails,
+            seasons: expectedSeasons,
+        }
+
+        League.prototype.execPopulate = jest.fn().mockResolvedValue(populatedObj)
+
+        await leagueController.getAllLeagueSeasons(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: expectedSeasons,
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+
+    test('Getting league seasons with no seasons should return empty seasons array', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        const leagueDetails = {
+            _id: '611a8a661fb4c81d84a5512c',
+            admins: ['611a8a311fb4c81d84a55126'],
+            seasons: [],
+            name: 'Joshua Basketball Association',
+            organisation: 'JoshuaDubar',
+            creator: '611a8a311fb4c81d84a55126',
+            __v: 8,
+        }
+        req.league = new League(leagueDetails)
+
+        League.prototype.execPopulate = jest.fn().mockResolvedValue(leagueDetails)
+
+        await leagueController.getAllLeagueSeasons(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: [],
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+})
+
+describe('Unit Testing: createLeagueSeason in leagueController', () => {
+    test('Creating season with valid seasonName, seasonStart and seasonFinish should create a season', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        req.league = new League({
+            _id: '611bbfe2aaa94829988d0b18',
+            admin: ['611a8a311fb4c81d84a55126'],
+            seasons: [],
+            name: 'Joshua Basketball Association',
+            organisation: 'JoshuaDubar',
+            creator: '611a8a311fb4c81d84a55126',
+            __v: 0,
+        })
+
+        req.body = {
+            seasonName: 'jdubzSeason',
+            seasonStart: '2021-08-12T12:23:34.944Z',
+            seasonFinish: '2021-08-24T12:23:34.944Z',
+        }
+
+        const expectedSeason = new Season({
+            name: 'jdubzSeason',
+            dateStart: '2021-08-12T12:23:34.944Z',
+            dateFinish: '2021-08-24T12:23:34.944Z',
+            league: '611bbfe2aaa94829988d0b18',
+            grades: [],
+            __v: 0,
+            status: 'upcoming',
+        })
+
+        League.prototype.save = jest.fn().mockImplementationOnce()
+        Season.prototype.save = jest.fn().mockResolvedValue(expectedSeason)
+        await leagueController.createLeagueSeason(req, res, next)
+
+        const actualRes = {
+            status: 201,
+            json: {
+                success: true,
+                data: expectedSeason,
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+})
+
+describe('Unit Testing: createLeagueAdmins in leagueController', () => {
+    test('Adding new user with valid id should be added to League.admins', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        const leagueDetails = {
+            _id: '611bbfe2aaa94829988d0b18',
+            admin: ['611a8a311fb4c81d84a55126'],
+            seasons: [],
+            name: 'Joshua Basketball Association',
+            organisation: 'JoshuaDubar',
+            creator: '611a8a311fb4c81d84a55126',
+            __v: 0,
+        }
+
+        const user = {
+            _id: '611a8ba31fb4c81d84a5513b',
+            email: 'jdubz@dribblr.com',
+            password: 'Password!',
+            firstName: 'Joshua',
+            lastName: 'Dubar',
+            leagues: [],
+        }
+
+        req.league = new League(leagueDetails)
+
+        req.body = {
+            adminIds: ['611a8ba31fb4c81d84a5513b'],
+        }
+
+        const expectedLeague = new League({
+            ...leagueDetails,
+            admins: ['611a8ba31fb4c81d84a5513b', '611a8a311fb4c81d84a55126'],
+        })
+
+        User.findOneAndUpdate = jest
+            .fn()
+            .mockResolvedValue(new User({ ...user, leagues: ['611bbfe2aaa94829988d0b18'] }))
+
+        League.findOneAndUpdate = jest.fn().mockResolvedValue(expectedLeague)
+
+        await leagueController.createLeagueAdmins(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: expectedLeague.admins,
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+
+    test('Adding existing admin with valid id should return same League.admins', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        const leagueDetails = {
+            _id: '611bbfe2aaa94829988d0b18',
+            admin: ['611a8a311fb4c81d84a55126', '611a8ba31fb4c81d84a5513b'],
+            seasons: [],
+            name: 'Joshua Basketball Association',
+            organisation: 'JoshuaDubar',
+            creator: '611a8a311fb4c81d84a55126',
+            __v: 0,
+        }
+
+        const user = {
+            _id: '611a8ba31fb4c81d84a5513b',
+            email: 'jdubz@dribblr.com',
+            password: 'Password!',
+            firstName: 'Joshua',
+            lastName: 'Dubar',
+            leagues: [],
+        }
+
+        req.league = new League(leagueDetails)
+
+        req.body = {
+            adminIds: ['611a8ba31fb4c81d84a5513b'],
+        }
+
+        const expectedLeague = new League(leagueDetails)
+
+        User.findOneAndUpdate = jest
+            .fn()
+            .mockResolvedValue(new User({ ...user, leagues: ['611bbfe2aaa94829988d0b18'] }))
+
+        League.findOneAndUpdate = jest.fn().mockResolvedValue(expectedLeague)
+
+        await leagueController.createLeagueAdmins(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: expectedLeague.admins,
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+
+    test('Adding user with invalid id should return some users do not exist error', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        req.league = new League({
+            _id: '611bbfe2aaa94829988d0b18',
+            admin: ['611a8a311fb4c81d84a55126'],
+            seasons: [],
+            name: 'Joshua Basketball Association',
+            organisation: 'JoshuaDubar',
+            creator: '611a8a311fb4c81d84a55126',
+            __v: 0,
+        })
+
+        req.body = {
+            adminIds: ['jdubz'],
+        }
+
+        User.findOneAndUpdate = jest.fn().mockResolvedValue(null)
+
+        await leagueController.createLeagueAdmins(req, res, next)
+
+        const actualNext = {
+            status: 404,
+            message: 'Some users do not exist',
+        }
+
+        expect(next).toHaveBeenCalledWith(actualNext)
+    })
+})
+
+describe('Unit Testing: deleteLeagueAdmins in leagueController', () => {
+    test('Deleting existing admin with valid id should be removed from League.admins', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        const leagueDetails = {
+            _id: '611bbfe2aaa94829988d0b18',
+            admin: ['611a8a311fb4c81d84a55126', '611a8ba31fb4c81d84a5513b'],
+            seasons: [],
+            name: 'Joshua Basketball Association',
+            organisation: 'JoshuaDubar',
+            creator: '611a8a311fb4c81d84a55126',
+            __v: 0,
+        }
+
+        const user = {
+            _id: '611a8ba31fb4c81d84a5513b',
+            email: 'jdubz@dribblr.com',
+            password: 'Password!',
+            firstName: 'Joshua',
+            lastName: 'Dubar',
+            leagues: [],
+        }
+
+        req.league = new League(leagueDetails)
+
+        req.body = {
+            adminIds: ['611a8ba31fb4c81d84a5513b'],
+        }
+
+        const expectedLeague = new League({
+            ...leagueDetails,
+            admins: ['611a8a311fb4c81d84a55126'],
+        })
+
+        User.findOneAndUpdate = jest
+            .fn()
+            .mockResolvedValue(new User({ ...user, leagues: ['611bbfe2aaa94829988d0b18'] }))
+
+        League.findOneAndUpdate = jest.fn().mockResolvedValue(expectedLeague)
+
+        await leagueController.deleteLeagueAdmins(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: expectedLeague.admins,
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+
+    test('Deleting non-existing admin with valid id should return original League.admins', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        const leagueDetails = {
+            _id: '611bbfe2aaa94829988d0b18',
+            admin: ['611a8a311fb4c81d84a55126'],
+            seasons: [],
+            name: 'Joshua Basketball Association',
+            organisation: 'JoshuaDubar',
+            creator: '611a8a311fb4c81d84a55126',
+            __v: 0,
+        }
+
+        const user = {
+            _id: '611a8ba31fb4c81d84a5513b',
+            email: 'jdubz@dribblr.com',
+            password: 'Password!',
+            firstName: 'Joshua',
+            lastName: 'Dubar',
+            leagues: [],
+        }
+
+        req.league = new League(leagueDetails)
+
+        req.body = {
+            adminIds: ['611a8ba31fb4c81d84a5513b'],
+        }
+
+        const expectedLeague = new League(leagueDetails)
+
+        User.findOneAndUpdate = jest
+            .fn()
+            .mockResolvedValue(new User({ ...user, leagues: ['611bbfe2aaa94829988d0b18'] }))
+
+        League.findOneAndUpdate = jest.fn().mockResolvedValue(expectedLeague)
+
+        await leagueController.deleteLeagueAdmins(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: expectedLeague.admins,
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+
+    test('Deleting user with invalid id should return some users do not exist error', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        req.league = new League({
+            _id: '611bbfe2aaa94829988d0b18',
+            admin: ['611a8a311fb4c81d84a55126'],
+            seasons: [],
+            name: 'Joshua Basketball Association',
+            organisation: 'JoshuaDubar',
+            creator: '611a8a311fb4c81d84a55126',
+            __v: 0,
+        })
+
+        req.body = {
+            adminIds: ['jdubz'],
+        }
+
+        User.findOneAndUpdate = jest.fn().mockResolvedValue(null)
+
+        await leagueController.deleteLeagueAdmins(req, res, next)
+
+        const actualNext = {
+            status: 404,
+            message: 'Some users do not exist',
+        }
+
+        expect(next).toHaveBeenCalledWith(actualNext)
+    })
+})

--- a/server/tests/unit/seasonController.test.js
+++ b/server/tests/unit/seasonController.test.js
@@ -1,0 +1,212 @@
+const seasonController = require('../../controllers/seasonController')
+const Season = require('../../models/season')
+const Grade = require('../../models/grade')
+const { mockRequest, mockResponse, mockNext } = require('./test-utils')
+
+describe('Unit Testing: getAllSeasonGrades in seasonController', () => {
+    test('Getting season grades with 1 grade should return populated grade', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        const seasonDetails = {
+            _id: '60741060d14008bd0efff9d5',
+            status: 'upcoming',
+            grades: ['611ba1c73dc3af241c95e7e2'],
+            name: 'Summer 2020/2021',
+            league: '611a8a661fb4c81d84a5512c',
+            dateStart: '2021-08-12T12:23:34.944Z',
+            dateFinish: '2021-08-14T12:23:34.944Z',
+            __v: 0,
+        }
+        req.season = new Season(seasonDetails)
+
+        const expectedGrades = [
+            {
+                difficulty: 'A',
+                gender: 'male',
+                teams: [],
+                _id: '611ba1c73dc3af241c95e7e2',
+                name: 'Male A Grade',
+                season: '60741060d14008bd0efff9d5',
+                __v: 0,
+            },
+        ]
+
+        // We expect execPopulate to populate the grades array with the full document
+        const populatedObj = {
+            ...seasonDetails,
+            grades: expectedGrades,
+        }
+
+        Season.prototype.execPopulate = jest.fn().mockResolvedValue(populatedObj)
+
+        await seasonController.getAllSeasonGrades(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: expectedGrades,
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+
+    test('Getting season grades with no grades should return empty grades array', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+        const seasonDetails = {
+            _id: '60741060d14008bd0efff9d5',
+            status: 'upcoming',
+            grades: [],
+            name: 'Summer 2020/2021',
+            league: '611a8a661fb4c81d84a5512c',
+            dateStart: '2021-08-12T12:23:34.944Z',
+            dateFinish: '2021-08-14T12:23:34.944Z',
+            __v: 0,
+        }
+
+        req.season = new Season(seasonDetails)
+
+        Season.prototype.execPopulate = jest.fn().mockResolvedValue(seasonDetails)
+
+        await seasonController.getAllSeasonGrades(req, res, next)
+
+        const actualRes = {
+            status: 200,
+            json: {
+                success: true,
+                data: [],
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+})
+
+describe('Unit Testing: createGrade in seasonController', () => {
+    test('Creating grade with valid gender, difficulty and season should create a grade', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        req.season = new Season({
+            _id: '60741060d14008bd0efff9d5',
+            status: 'upcoming',
+            grades: [],
+            name: 'Summer 2020/2021',
+            league: '611a8a661fb4c81d84a5512c',
+            dateStart: '2021-08-12T12:23:34.944Z',
+            dateFinish: '2021-08-14T12:23:34.944Z',
+            __v: 0,
+        })
+
+        req.body = {
+            gradeName: 'jdubz',
+            gradeGender: 'male',
+            gradeDifficulty: 'A',
+        }
+
+        const expectedGrade = new Grade({
+            _id: '612788ed698aac7c50c3d3b6',
+            name: 'jdubz',
+            gender: 'male',
+            difficulty: 'A',
+            season: '60741060d14008bd0efff9d5',
+            teams: [],
+        })
+
+        Season.prototype.save = jest.fn().mockImplementationOnce()
+        Grade.prototype.save = jest.fn().mockResolvedValue(expectedGrade)
+        await seasonController.createGrade(req, res, next)
+
+        const actualRes = {
+            status: 201,
+            json: {
+                success: true,
+                data: expectedGrade,
+            },
+        }
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(actualRes.status)
+        expect(res.json).toHaveBeenCalledTimes(1)
+        expect(res.json).toHaveBeenCalledWith(actualRes.json)
+    })
+
+    test('Creating grade with invalid gender should return Invalid gender error', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        req.season = new Season({
+            _id: '60741060d14008bd0efff9d5',
+            status: 'upcoming',
+            grades: [],
+            name: 'Summer 2020/2021',
+            league: '611a8a661fb4c81d84a5512c',
+            dateStart: '2021-08-12T12:23:34.944Z',
+            dateFinish: '2021-08-14T12:23:34.944Z',
+            __v: 0,
+        })
+
+        req.body = {
+            gradeName: 'jdubz',
+            gradeGender: 'joshuaSandwich',
+            gradeDifficulty: 'A',
+        }
+
+        await seasonController.createGrade(req, res, next)
+
+        const actualNext = {
+            status: 400,
+            message: 'Invalid gender',
+        }
+
+        expect(next).toHaveBeenCalledWith(actualNext)
+    })
+
+    test('Creating grade with invalid difficulty should return Invalid difficulty error', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        req.season = new Season({
+            _id: '60741060d14008bd0efff9d5',
+            status: 'upcoming',
+            grades: [],
+            name: 'Summer 2020/2021',
+            league: '611a8a661fb4c81d84a5512c',
+            dateStart: '2021-08-12T12:23:34.944Z',
+            dateFinish: '2021-08-14T12:23:34.944Z',
+            __v: 0,
+        })
+
+        req.body = {
+            gradeName: 'jdubz',
+            gradeGender: 'male',
+            gradeDifficulty: 'joshua',
+        }
+
+        await seasonController.createGrade(req, res, next)
+
+        const actualNext = {
+            status: 400,
+            message: 'Invalid difficulty',
+        }
+
+        expect(next).toHaveBeenCalledWith(actualNext)
+    })
+})

--- a/server/tests/unit/test-utils.js
+++ b/server/tests/unit/test-utils.js
@@ -1,0 +1,17 @@
+module.exports = {
+    mockRequest: () => {
+        const req = {}
+        req.body = jest.fn().mockReturnValue(req)
+        req.params = jest.fn().mockReturnValue(req)
+        return req
+    },
+
+    mockResponse: () => {
+        const res = {}
+        res.status = jest.fn().mockReturnValue(res)
+        res.json = jest.fn().mockReturnValue(res)
+        return res
+    },
+
+    mockNext: () => jest.fn(),
+}


### PR DESCRIPTION
PR for unit tests
- Made some adjustments to some of the controllers (eg. instead of await newLeague.save(), I returned the object, this is because I was finding it difficult to mock the return value for the tests, and so I thought storing it as a variable wouldn't change any existing functionality, but makes writing the tests easier)
- Clean up bugs with add/remove admins
- Added some new required validators on some models.