### PR TITLE
delete round

### DIFF
--- a/server/controllers/roundController.js
+++ b/server/controllers/roundController.js
@@ -15,6 +15,16 @@ async function getRound(req, res, next) {
     }
 }
 
+async function deleteRound(req, res, next) {
+    try {
+        await req.round.deleteOne({ _id: req.round._id })
+        return res.status(204).send()
+    } catch (err) {
+        console.log(err)
+        return next(err)
+    }
+}
+
 async function createGame(req, res, next) {
     try {
         let { start, finish, venue_name, game_location, team1_id, team2_id } = req.body
@@ -72,5 +82,6 @@ async function createGame(req, res, next) {
 
 module.exports = {
     getRound,
+    deleteRound,
     createGame,
 }

--- a/server/docs/round.yaml
+++ b/server/docs/round.yaml
@@ -96,6 +96,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/RoundNotFoundResponse'
 
+    delete:
+      tags:
+        - 'Round'
+      summary: 'Delete round by id.'
+      parameters:
+      - name: 'roundId'
+        in: 'path'
+        description: 'ID of round to delete.'
+        required: true
+        type: 'string'
+      security:
+      - BearerAuth: []
+      responses:
+        '204':
+          description: 'Successfully deleted a round.'
+        '403':
+          description: 'User is not an admin for this league.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserNotAdminResponse'
+        '404':
+          description: 'Round does not exist.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoundNotFoundResponse'
+
   /round/{roundId}/game:
     post:
       tags:

--- a/server/docs/season.yaml
+++ b/server/docs/season.yaml
@@ -130,11 +130,11 @@ paths:
         '204':
           description: 'Successfully deleted a season.'
         '403':
-          description: 'User is not the creator for this league.'
+          description: 'User is not an admin for this league.'
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserNotCreatorResponse'
+                $ref: '#/components/schemas/UserNotAdminResponse'
         '404':
           description: 'Season does not exist.'
           content:

--- a/server/routes/roundRouter.js
+++ b/server/routes/roundRouter.js
@@ -19,4 +19,12 @@ roundRouter.post(
     roundController.createGame
 )
 
+// DELETE
+roundRouter.delete(
+    '/:roundId',
+    ensureAuthenticated,
+    ensureLeagueAdmin,
+    roundController.deleteRound
+)
+
 module.exports = roundRouter

--- a/server/tests/integration/round.test.js
+++ b/server/tests/integration/round.test.js
@@ -196,3 +196,39 @@ describe('Integration Testing: creating games', () => {
     })
 
 })
+
+describe('Integration Testing: deleting a round', () => {
+    test('Deleting a round with a nonexistent id should return an error', async () => {
+        const res = await request.delete(`/api/round/aaaabbbbcccc`)
+            .set('Authorization', `Bearer ${env.auth_tokens[0][1]}`)
+
+        expect(res.statusCode).toBe(404)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error).toBe('Round does not exist')
+    })
+
+    test('Deleting a round with an invalid MongoDB object id should return an error', async () => {
+        const res = await request.delete(`/api/round/1337`)
+            .set('Authorization', `Bearer ${env.auth_tokens[0][1]}`)
+
+        expect(res.statusCode).toBe(404)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error).toBe('Round does not exist')
+    })
+
+    test('A user should not be able to delete a round if they are not a league admin', async () => {
+        const res = await request.delete(`/api/round/${env.round0_id}`)
+            .set('Authorization', `Bearer ${env.auth_tokens[2][1]}`)
+
+        expect(res.statusCode).toBe(403)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error).toBe('User is not an admin')
+    })
+
+    test('Should be able to delete a round with valid id', async () => {
+        const res = await request.delete(`/api/round/${env.round0_id}`)
+            .set('Authorization', `Bearer ${env.auth_tokens[0][1]}`)
+
+        expect(res.statusCode).toBe(204)
+    })
+})

--- a/server/tests/integration/season.test.js
+++ b/server/tests/integration/season.test.js
@@ -181,6 +181,16 @@ describe('Integration Testing: deleting a season', () => {
         expect(res.body.error).toBe('Season does not exist')
     })
 
+    test('A user should not be able to delete a season if they are not a league admin', async () => {
+        const res = await request.delete(`/api/season/${env.season0_id}`)
+            .set('Authorization', `Bearer ${env.auth_tokens[2][1]}`)
+
+        expect(res.statusCode).toBe(403)
+        expect(res.body.success).toBe(false)
+        expect(res.body.error).toBe('User is not an admin')
+    })
+
+
     test('Should be able to delete a season with valid id', async () => {
         const res = await request.delete(`/api/season/${env.season1_id}`)
             .set('Authorization', `Bearer ${env.auth_tokens[0][1]}`)

--- a/server/tests/unit/roundController.test.js
+++ b/server/tests/unit/roundController.test.js
@@ -155,3 +155,26 @@ describe('Unit Testing: createGame in roundController', () => {
         expect(next).toHaveBeenCalledWith(actualNext)
     })
 })
+
+
+describe('Unit Testing: deleteRound in roundController', () => {
+    test('Deleting round with valid roundId should delete the season', async () => {
+        const req = mockRequest()
+        const res = mockResponse()
+        const next = mockNext()
+
+        req.round = new Round({
+            _id: '60741060d14008bd0efff9d5',
+            grade: '60741060d14008bd0efaaaaa',
+            dateStart: '2021-08-12T12:23:34.944Z',
+        })
+
+        Round.prototype.deleteOne = jest.fn().mockImplementationOnce()
+
+        await roundController.deleteRound(req, res, next)
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(204)
+    })
+})


### PR DESCRIPTION
- updated docs for season to reflect that league admins can delete seasons (not just creators)
- also added tests for this
- added endpoint and controller to delete round + tests + docs
